### PR TITLE
Add Skynet support with github automation

### DIFF
--- a/.github/workflows/deploy-to-skynet.yml
+++ b/.github/workflows/deploy-to-skynet.yml
@@ -1,0 +1,26 @@
+name: Deploy to Skynet
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16.x
+
+      - run: yarn
+      - run: yarn build:prod
+
+      - name: Deploy to Skynet
+        uses: skynetlabs/deploy-to-skynet-action@v2
+        with:
+          upload-dir: build
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          registry-seed: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && secrets.SKYNET_REGISTRY_SEED || '' }}


### PR DESCRIPTION
This pull request adds automated deploys to [Skynet](https://siasky.net/about) - decentralised hosting platform built on top of [Sia](https://sia.tech/) network.

[Deploy to Skynet](https://github.com/marketplace/actions/skynet-deploy) github action will be configured to run for every push to master branch and also every pull request.

This action will install yarn dependencies, run production build command and upload the output directory to Skynet. As a result, every time it uploads new sources, it will produce unique [skylink](https://support.siasky.net/key-concepts/skylinks) (immutable public pointer to uploaded content, similar to ipfs cid) that can be used to access this specific deployed version.

For pull request, after each change, it will post a comment with unique skylink - this is very useful for verifying code changes (similar to [Netlify Deploy Previews](https://www.netlify.com/blog/2016/07/20/introducing-deploy-previews-in-netlify/)).

In addition, for production build (the one that runs on every master branch changes, also configurable), it will use SKYNET_REGISTRY_SEED [github secret](https://docs.github.com/en/actions/security-guides/encrypted-secrets) to produce a [resolver skylink](https://docs.siasky.net/skynet-topics/resolver-skylinks) - similar to a regular skylink but always points to a latest deploy.

**Maintainer required actions:**

Maintainer should add SKYNET_REGISTRY_SEED github secret that would serve as a private key to generate resolver skylink for production releases. Value should be cryptographically secure random seed string - I usually use https://randomkeygen.com/ but it is up for maintainer to generate it and store securely. I suggest doing this before merging this pull request because merging it will already trigger the github actions for the first time and result in first deploy.

How to: [Creating encrypted secrets for a repository
](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository)

The first time the action is ran (with the seed in github secret), maintainer should go to Deploy to Skynet action in the Actions tab, open up action logs and copy the resolver skylink url. I suggest adding the skylink url to github readme and application footer.

**Alternate deploy strategies:**

This pull request assumes that maintainer wants to update production deploy with the latest build based on master branch. Alternatively, github action can be reconfigured for example to deploy only tags. If this project utilises manual deploys and continuous deployment is not something of interest then I can also provide a manual deploy script that does exactly the same thing but can be ran as a yarn script.

**Example integration result:**

1inch official website: https://app.1inch.io/
1inch Skynet skylink: 0405maluitpg3lg7e632idp7qeqq9mo6rr6rv3gli8lchh9g64gbtag
1inch Skynet deploy: https://0405maluitpg3lg7e632idp7qeqq9mo6rr6rv3gli8lchh9g64gbtag.siasky.net/

1inch supports Skynet deploys, official link can be found under More in top menu.