### PR TITLE
Persist Sign-in Across Page Refresh

### DIFF
--- a/src/AppRoutes.js
+++ b/src/AppRoutes.js
@@ -1,10 +1,19 @@
+import { useSelector } from 'react-redux'
 import React from 'react'
 import { BrowserRouter as Router, Switch, Route } from 'react-router-dom'
 import TradePage from 'components/pages/TradePage/TradePage'
 import BridgePage from 'components/pages/BridgePage/BridgePage'
 import PoolPage from 'components/pages/PoolPage/PoolPage'
+import { networkSelector } from 'lib/store/features/api/apiSlice'
+import api from 'lib/api'
 
 const AppRoutes = () => {
+  // persist login across sessions
+  const network = useSelector(networkSelector)
+  if (localStorage.getItem("zksync:seed")) {
+    api.signIn(network);
+  }
+
   return (
     <>
       <Router>

--- a/src/AppRoutes.js
+++ b/src/AppRoutes.js
@@ -10,7 +10,7 @@ import api from 'lib/api'
 const AppRoutes = () => {
   // persist login across sessions
   const network = useSelector(networkSelector)
-  if (localStorage.getItem("zksync:seed")) {
+  if (localStorage.getItem("zksync:seed") && api.isZksyncChain(network)) {
     api.signIn(network);
   }
 

--- a/src/components/molecules/SpotForm/SpotForm.jsx
+++ b/src/components/molecules/SpotForm/SpotForm.jsx
@@ -20,7 +20,7 @@ export class SpotForm extends React.Component {
             WETH: 0.0001,
             USDC: 1,
             USDT: 1,
-            WBTC: 0.0002,
+            WBTC: 0.00003,
             DAI: 1,
             FRAX: 1,
             FXS: 0.1,

--- a/src/lib/api/API.js
+++ b/src/lib/api/API.js
@@ -200,6 +200,8 @@ export default class API extends Emitter {
     }
 
     signOut = async () => {
+        localStorage.removeItem("zksync:seed");
+        localStorage.removeItem("zksync:eth_signature_type");
         this.web3Modal.clearCachedProvider()
         this.emit('signOut')
     }

--- a/src/lib/api/providers/APIZKProvider.js
+++ b/src/lib/api/providers/APIZKProvider.js
@@ -226,7 +226,21 @@ export default class APIZKProvider extends APIProvider {
         }
 
         this.ethWallet = this.api.ethersProvider.getSigner()
-        const { seed, ethSignatureType } = await this.genSeed(this.ethWallet);
+
+        let seed, ethSignatureType;
+        if (localStorage.getItem("zksync:seed")) {
+            ethSignatureType = localStorage.getItem("zksync:eth_signature_type");
+            const jsonSeed = localStorage.getItem("zksync:seed");
+            seed = Uint8Array.from(JSON.parse(jsonSeed));
+        }
+        else {
+            const genSeedResult = await this.genSeed(this.ethWallet);
+            seed = genSeedResult.seed;
+            ethSignatureType = genSeedResult.ethSignatureType;
+            const jsonSeed = JSON.stringify(Array.from(seed));
+            localStorage.setItem("zksync:seed", jsonSeed);
+            localStorage.setItem("zksync:eth_signature_type", ethSignatureType);
+        }
         const syncSigner = await zksync.Signer.fromSeed(seed);
         this.syncWallet = await zksync.Wallet.fromEthSigner(this.ethWallet, this.syncProvider, syncSigner, undefined, ethSignatureType)        
         const accountState = await this.api.getAccountState()


### PR DESCRIPTION
If you've already signed the Metamask provider message once, it will store the seed from that approval and use it again on page refresh. 

This needs to be tested before merging but the feature is complete.