### PR TITLE
Change default market to ETH-USDC

### DIFF
--- a/src/lib/store/features/api/apiSlice.js
+++ b/src/lib/store/features/api/apiSlice.js
@@ -9,7 +9,7 @@ export const authSlice = createSlice({
   initialState: {
     network: 1,
     userId: null,
-    currentMarket: 'ETH-USDT',
+    currentMarket: 'ETH-USDC',
     marketFills: {},
     bridgeReceipts: [],
     lastPrices: {},


### PR DESCRIPTION
ETH-USDC has become our most liquid pair, so this changes the default market to that. 