### PR TITLE
Fix for TradeRatesCard

### DIFF
--- a/src/components/pages/TradePage/TradeRatesCard/TradeRatesCard.css
+++ b/src/components/pages/TradePage/TradeRatesCard/TradeRatesCard.css
@@ -41,8 +41,12 @@
     color: white;
 }
 
-.rb_text_3 p {
+.rb_text_3_down_value p {
     color: #c4384e;
+}
+
+.rb_text_3_up_value  p {
+    color: #3fe199;
 }
 
 .rb_text_4 p {

--- a/src/components/pages/TradePage/TradeRatesCard/TradeRatesCard.jsx
+++ b/src/components/pages/TradePage/TradeRatesCard/TradeRatesCard.jsx
@@ -25,7 +25,13 @@ class TradeRatesCard extends React.Component {
                         <h1>{this.props.marketSummary.price}</h1>
                         <p>${this.props.marketSummary.price}</p>
                     </div>
-                    <div className="rates_box rb_text_3">
+                    <div
+                      className={
+                        this.props.marketSummary.priceChange < 0
+                          ? "rates_box rb_text_3_down_value"
+                          : "rates_box rb_text_3_up_value"
+                      }
+                    >
                         <h2>24h Change</h2>
                         <p>
                             {this.props.marketSummary.priceChange}{" "}


### PR DESCRIPTION
![bug](https://user-images.githubusercontent.com/95502080/149335198-539d91de-8429-4e43-9512-84bb607cd849.png)

The TradeRatesCard one the left has a static red colour. Should be changed to red or green depending on the marketSummary.priceChange.