### PR TITLE
fix/ UI not showing best bid/ask price

### DIFF
--- a/src/components/molecules/SpotForm/SpotForm.jsx
+++ b/src/components/molecules/SpotForm/SpotForm.jsx
@@ -86,7 +86,13 @@ export class SpotForm extends React.Component {
             baseBalance = 0;
             quoteBalance = 0;
         }
-        const price = this.currentPrice();
+        let price = this.currentPrice();
+        if (this.props.side === "b") {
+            price = (price * 1.001).toFixed(marketInfo.pricePrecisionDecimals);
+        }
+        else if (this.props.side === "s") {
+            price = (price * 0.999).toFixed(marketInfo.pricePrecisionDecimals);
+        }
 
         baseBalance = parseFloat(baseBalance);
         quoteBalance = parseFloat(quoteBalance);
@@ -184,10 +190,10 @@ export class SpotForm extends React.Component {
         }
 
         if (this.props.side === "b") {
-            return (this.getFirstAsk() * 1.001).toFixed(marketInfo.pricePrecisionDecimals);
+            return (this.getFirstAsk()).toFixed(marketInfo.pricePrecisionDecimals);
         }
         else if (this.props.side === "s") {
-            return (this.getFirstBid() * 0.999).toFixed(marketInfo.pricePrecisionDecimals);
+            return (this.getFirstBid()).toFixed(marketInfo.pricePrecisionDecimals);
         }
         return 0;
     }


### PR DESCRIPTION
The UI displayed the factor of 1.001. That factor is too big for eg. ETH with $3200 that would be $3.2:
![grafik](https://user-images.githubusercontent.com/95502080/150507287-8445877a-88e5-4a47-8efd-dcdb4f926932.png)


Fix: Display will only show the 'true' price and margin will only be added to buySellHandler. 

