### PR TITLE
Allow limit orders to 5%

### DIFF
--- a/src/components/molecules/SpotForm/SpotForm.jsx
+++ b/src/components/molecules/SpotForm/SpotForm.jsx
@@ -132,9 +132,9 @@ export class SpotForm extends React.Component {
         }
         if (this.props.orderType === 'market') {
             if (this.props.side === 'b') {
-                price *= 1.0005;
+                price *= 1.0008;
             } else if (this.props.side === 's') {
-                price *= 0.9995;
+                price *= 0.9992;
             }
         }
 

--- a/src/components/molecules/SpotForm/SpotForm.jsx
+++ b/src/components/molecules/SpotForm/SpotForm.jsx
@@ -166,7 +166,7 @@ export class SpotForm extends React.Component {
             return;
         } else if (
             (this.props.side === 'b' && price > this.getFirstAsk() * 1.05) ||
-            (this.props.side === 's' && price < this.getFirstBid() * 0.995)
+            (this.props.side === 's' && price < this.getFirstBid() * 0.95)
         ) {
             toast.error("Limit orders cannot exceed 5% beyond spot");
             return;


### PR DESCRIPTION
A bug was only allowing sell limit orders to extend 0.5% past spot instead of 5%.

Additionally an extra 0.03% of clearance was added to market orders to give a better chance at a fill. 