### PR TITLE
Small fixes

### DIFF
--- a/src/components/molecules/SpotForm/SpotForm.jsx
+++ b/src/components/molecules/SpotForm/SpotForm.jsx
@@ -304,6 +304,10 @@ export class SpotForm extends React.Component {
         ) {
             this.rangeSliderHandler(null, 100);
         }
+
+        if (this.props.currentMarket !== prevProps.currentMarket) {
+            this.setState((state) => ({...state, price: "", amount: ""}));
+        }
     }
 
     render() {
@@ -351,7 +355,7 @@ export class SpotForm extends React.Component {
         <>
           <form className="spot_form">
             <div className="spf_head">
-              <span>Avbl</span>
+              <span>Available balance</span>
               {balanceHtml}
             </div>
             <div className="spf_input_box">

--- a/src/components/organisms/Header/Header.jsx
+++ b/src/components/organisms/Header/Header.jsx
@@ -76,7 +76,7 @@ export const Header = (props) => {
                 </li>}
                 <li>
                   <NavLink exact to="/list-pair" activeClassName="active_link">
-                    List
+                    List Pair
                   </NavLink>
                 </li>
                 <Dev>
@@ -143,7 +143,7 @@ export const Header = (props) => {
               </li>}
               <li>
                 <NavLink exact to="/list-pair" activeClassName="active_link">
-                  List
+                  List Pair
                 </NavLink>
               </li>
               {hasBridge && <li>

--- a/src/components/organisms/Header/HeaderBridge.jsx
+++ b/src/components/organisms/Header/HeaderBridge.jsx
@@ -55,7 +55,7 @@ export const HeaderBridge = (props) => {
               </li>
               <li>
                 <NavLink exact to="/list-pair" activeClassName="active_link">
-                  List
+                  List Pair
                 </NavLink>
               </li>
               <li>

--- a/src/components/pages/TradePage/TradePriceTable/TradePriceTable.jsx
+++ b/src/components/pages/TradePage/TradePriceTable/TradePriceTable.jsx
@@ -49,8 +49,8 @@ const TradePriceTable = (props) => {
                 rowStyle = {};
               }
               const price = typeof d.td1 === "number" ? d.td1.toPrecision(6) : d.td1;
-              const amount = Number(typeof d.td2 === "number" ? d.td2.toPrecision(6) : d.td2);
-              const total = Math.round(typeof d.td3 === "number" ? d.td3.toPrecision(6) : d.td3);
+              const amount = typeof d.td2 === "number" ? d.td2.toPrecision(6) : d.td2;
+              const total = typeof d.td3 === "number" ? d.td3.toPrecision(6) : d.td3;
               return (
                 <tr key={i} style={rowStyle} onClick={() => onClickRow(d)}>
                   <td className={d.side === "b" ? "up_value" : "down_value"}>

--- a/src/components/pages/TradePage/TradePriceTable/TradePriceTable.jsx
+++ b/src/components/pages/TradePage/TradePriceTable/TradePriceTable.jsx
@@ -49,8 +49,8 @@ const TradePriceTable = (props) => {
                 rowStyle = {};
               }
               const price = typeof d.td1 === "number" ? d.td1.toPrecision(6) : d.td1;
-              const amount = typeof d.td2 === "number" ? d.td2.toPrecision(6) : d.td2;
-              const total = typeof d.td3 === "number" ? d.td3.toPrecision(6) : d.td3;
+              const amount = Number(typeof d.td2 === "number" ? d.td2.toPrecision(6) : d.td2);
+              const total = Math.round(typeof d.td3 === "number" ? d.td3.toPrecision(6) : d.td3);
               return (
                 <tr key={i} style={rowStyle} onClick={() => onClickRow(d)}>
                   <td className={d.side === "b" ? "up_value" : "down_value"}>


### PR DESCRIPTION
- Change “List” into “List Pair” (in category)
- Change "Avbl" to "Available balance"
- Clear the price & amount field on trade UI when people switch between markets
- Remove excess decimals/zeros in orderbook
  - Use Number constructor to convert things like "0.050000" to 0.05 and "343.000000" to 343
  - Round total to nearest integer
![new_formatting](https://user-images.githubusercontent.com/17328289/153103949-a1b3e073-50f6-4475-8bd0-4df3a4226355.PNG)

