### PR TITLE
Use the staging server for Rinkeby markets

### DIFF
--- a/src/lib/api/API.js
+++ b/src/lib/api/API.js
@@ -92,6 +92,16 @@ export default class API extends Emitter {
             })
         }
 
+        // Change WebSocket if necessary
+        if (this.ws) {
+            const oldUrl = new URL(this.ws.url);
+            const newUrl = new URL(this.apiProvider.websocketUrl);
+            if (oldUrl.host !== newUrl.host) {
+                // Stopping the WebSocket will trigger an auto-restart in 3 seconds
+                this.stop();
+            }
+        }
+
         this.getAccountState()
             .catch(err => {
                 console.log('Failed to switch providers', err)

--- a/src/lib/api/API.js
+++ b/src/lib/api/API.js
@@ -69,6 +69,16 @@ export default class API extends Emitter {
 
         const apiProvider = this.getAPIProvider(network) 
         this.apiProvider = apiProvider
+
+        // Change WebSocket if necessary
+        if (this.ws) {
+            const oldUrl = new URL(this.ws.url);
+            const newUrl = new URL(this.apiProvider.websocketUrl);
+            if (oldUrl.host !== newUrl.host) {
+                // Stopping the WebSocket will trigger an auto-restart in 3 seconds
+                this.stop();
+            }
+        }
         
         if (this.isZksyncChain()) {
             this.web3 = new Web3(
@@ -90,16 +100,6 @@ export default class API extends Emitter {
                     }
                 }
             })
-        }
-
-        // Change WebSocket if necessary
-        if (this.ws) {
-            const oldUrl = new URL(this.ws.url);
-            const newUrl = new URL(this.apiProvider.websocketUrl);
-            if (oldUrl.host !== newUrl.host) {
-                // Stopping the WebSocket will trigger an auto-restart in 3 seconds
-                this.stop();
-            }
         }
 
         this.getAccountState()


### PR DESCRIPTION
1. We need a test server we can use to push new backend code before sending it over to mainnet  
2. The Rinkeby server load is causing performance issues on the mainnet server, so it's better to spin it off on its own