### PR TITLE
fix/change sellQuantityWithFee to sellQuantity to not sell more as set by user

### DIFF
--- a/src/lib/api/providers/APIZKProvider.js
+++ b/src/lib/api/providers/APIZKProvider.js
@@ -137,7 +137,7 @@ export default class APIZKProvider extends APIProvider {
             tokenBuy = marketInfo.quoteAssetId;
             tokenRatio[marketInfo.baseAssetId] = sellQuantityWithFee;
             tokenRatio[marketInfo.quoteAssetId] = (amount * price).toFixed(marketInfo.quoteAsset.decimals);
-            fullSellQuantity = (sellQuantityWithFee * 10**(marketInfo.baseAsset.decimals)).toLocaleString('fullwide', {useGrouping: false })
+            fullSellQuantity = (sellQuantity * 10**(marketInfo.baseAsset.decimals)).toLocaleString('fullwide', {useGrouping: false })
         }
 
         const now_unix = Date.now() / 1000 | 0


### PR DESCRIPTION
User sets amount inside the spot box.
sellQuantityWithFee should be used to calculate the token ration, so the price is set right and does include the fee (as before).

fullSellQuantity (used to generate the order) should not use the quantity with the fee included. It should use the amount set by the user (sellQuantity).

SpotBox (Sell):
![grafik](https://user-images.githubusercontent.com/95502080/153770991-8d3b6d98-2652-4bce-9610-542c84ab98ea.png)
Order:
![grafik](https://user-images.githubusercontent.com/95502080/153770999-a355c2ab-e77d-458a-aa88-c351014f40b9.png)
