### PR TITLE
Fix for bad rinkeby markets

### DIFF
--- a/src/lib/store/features/api/apiSlice.js
+++ b/src/lib/store/features/api/apiSlice.js
@@ -24,7 +24,12 @@ export const apiSlice = createSlice({
   },
   reducers: {
     _marketinfo(state, { payload }) {
-      state.marketinfo = payload[0];
+      if (payload[0].error) {
+          toast.error("Bad market");
+      }
+      else {
+          state.marketinfo = payload[0];
+      }
     },
     _fills(state, { payload }) {
       payload[0].forEach((fill) => {


### PR DESCRIPTION
Bad Rinkeby markets crash the site right now because `marketinfo` gets set to an object with an error in it.  