### PR TITLE
fix/dont buy more then account quote balance

### DIFF
--- a/src/lib/api/providers/APIZKProvider/APIZKProvider.js
+++ b/src/lib/api/providers/APIZKProvider/APIZKProvider.js
@@ -199,52 +199,6 @@ export default class APIZKProvider extends APIProvider {
         return this.accountState
     }
 
-    withdrawL2 = async (amountDecimals, token = 'ETH') => {
-        const currencyInfo = this.getCurrencyInfo(token);
-        const amount = toBaseUnit(amountDecimals, currencyInfo.decimals)
-
-        try {
-            const transfer = await this.syncWallet.withdrawFromSyncToEthereum({
-                token,
-                ethAddress: await this.ethWallet.getAddress(),
-                amount,
-            })
-
-            await transfer.awaitReceipt()
-            
-            this.api.emit('bridgeReceipt',
-                this.handleBridgeReceipt(transfer, amountDecimals, token, 'withdraw')
-            )
-            return transfer
-        } catch(err) {
-            console.log(err)
-        }
-    }
-
-    withdrawL2Fast = async (amountDecimals, token) => {
-      if (!this.eligibleFastWithdrawTokens.includes(token)) {
-        throw Error("Token not supported for fast withdraw")
-      }
-
-      const currencyInfo = this.getCurrencyInfo(token)
-      let amount = toBaseUnit(amountDecimals, currencyInfo.decimals)
-
-      // if amount is not packable
-      const isPackable = isTransactionAmountPackable(amount)
-      if (!isPackable) {
-        amount = closestPackableTransactionAmount(amount)
-      }
-
-      const transfer = await this.syncWallet.syncTransfer({
-        to: this._fastWithdrawContractAddress,
-        token,
-        amount
-      })
-      await transfer.awaitReceipt()
-
-      this.api.emit('bridgeReceipt', this.handleFastBridgeReceipt(transfer, amountDecimals, token, 'withdraw'))
-      return transfer
-    }
 
     depositL2 = async (amountDecimals, token = 'ETH') => {
         let transfer


### PR DESCRIPTION
closed https://github.com/ZigZagExchange/frontend/pull/82 to include rebase:
---
User sets amount inside the spot box.
sellQuantityWithFee should be used to calculate the token ration, so the price is set right and does include the fee (as before).

fullSellQuantity (used to generate the order) should not use the quantity with the fee included. It should use the amount set by the user (sellQuantity).

SpotBox (Sell):
![grafik](https://user-images.githubusercontent.com/95502080/153770991-8d3b6d98-2652-4bce-9610-542c84ab98ea.png)
Order:
![grafik](https://user-images.githubusercontent.com/95502080/153770999-a355c2ab-e77d-458a-aa88-c351014f40b9.png)
