### PR TITLE
Fix/bridge decimal rounding and max calculation

### DIFF
--- a/src/components/pages/BridgePage/Bridge/Bridge.jsx
+++ b/src/components/pages/BridgePage/Bridge/Bridge.jsx
@@ -285,6 +285,7 @@ const Bridge = () => {
             {transfer.type === 'withdraw' ? <L2Header/> : <L1Header/>}
           </div>
           <BridgeSwapInput
+            gasFee={L1Fee}
             bridgeFee={L2Fee}
             balances={balances}
             value={swapDetails}

--- a/src/components/pages/BridgePage/Bridge/Bridge.jsx
+++ b/src/components/pages/BridgePage/Bridge/Bridge.jsx
@@ -91,8 +91,9 @@ const Bridge = () => {
   }, [transfer.type])
 
   const validateInput = (inputValue, swapCurrency) => {
+    const swapCurrencyInfo = api.getCurrencyInfo(swapCurrency);
     const bals = transfer.type === 'deposit' ? walletBalances : zkBalances
-    const getCurrencyBalance = (cur) => parseFloat(bals[cur] && bals[cur].valueReadable) || 0
+    const getCurrencyBalance = (cur) => (bals[cur] && bals[cur] / (10**swapCurrencyInfo.decimals));
     const detailBalance = getCurrencyBalance(swapCurrency)
     let error = null
 

--- a/src/components/pages/BridgePage/BridgeSwapInput/BridgeSwapInput.jsx
+++ b/src/components/pages/BridgePage/BridgeSwapInput/BridgeSwapInput.jsx
@@ -51,25 +51,25 @@ const BridgeInputBox = styled.div`
   }
 `;
 
-const BridgeSwapInput = ({ value = {}, onChange, bridgeFee, balances = {}, feeCurrency }) => {
+const BridgeSwapInput = ({ value = {}, onChange, balances = {}, gasFee, bridgeFee, feeCurrency }) => {
   const setCurrency = useCallback(currency => onChange({ currency, amount: '' }), [onChange])
   const setAmount = useCallback(e => onChange({ amount: e.target.value.replace(/[^0-9.]/g,'') }), [onChange])
 
   const setMax = () => {
     let max;
     try {
-        const currencyInfo = api.getCurrencyInfo(value.currency);
-        const roundedDecimalDigits = Math.min(currencyInfo.decimals, 8);
-        const balance = balances[value.currency].value / (10 ** currencyInfo.decimals);
-        max = Math.round(balance * 10**roundedDecimalDigits) / 10**roundedDecimalDigits;
+      const currencyInfo = api.getCurrencyInfo(value.currency);
+      const roundedDecimalDigits = Math.min(currencyInfo.decimals, 8);
+      let balance = balances[value.currency].value / (10 ** currencyInfo.decimals);
+      if (feeCurrency === value.currency) {
+        balance -= (bridgeFee + gasFee);
+      }
+      max = Math.round(balance * 10**roundedDecimalDigits) / 10**roundedDecimalDigits;
     } catch (e) {
-        max = parseFloat((balances[value.currency] && balances[value.currency].valueReadable) || 0)
-    }
-    if (feeCurrency === value.currency) {
-      max -= parseFloat(bridgeFee)
+      max = parseFloat((balances[value.currency] && balances[value.currency].valueReadable) || 0)
     }
 
-    onChange({amount: max})
+    onChange({ amount: max })
   }
 
   return (

--- a/src/components/pages/BridgePage/BridgeSwapInput/BridgeSwapInput.jsx
+++ b/src/components/pages/BridgePage/BridgeSwapInput/BridgeSwapInput.jsx
@@ -1,6 +1,7 @@
 import React, { useCallback } from "react";
 import styled from "@xstyled/styled-components";
 import BridgeCurrencySelector from "../BridgeCurrencySelector/BridgeCurrencySelector";
+import api from "lib/api";
 
 const BridgeInputBox = styled.div`
   display: flex;
@@ -56,17 +57,11 @@ const BridgeSwapInput = ({ value = {}, onChange, bridgeFee, balances = {}, feeCu
 
   const setMax = () => {
     let max;
-    console.log(balances[value.currency]);
     try {
-        const integerValue = balances[value.currency].valueReadable.split('.')[0];
-        let integerDigits = 0;
-        if (integerValue !== '0') {
-            integerDigits = integerValue.length;
-        }
-        const decimalDigits = balances[value.currency].value.length - integerDigits;
-        console.log(integerDigits, decimalDigits);
-        max = balances[value.currency].value / (10 ** decimalDigits);
-        max = Math.floor(max * 10**8) / 10**8; // 8 decimal places max
+        const currencyInfo = api.getCurrencyInfo(value.currency);
+        const roundedDecimalDigits = Math.min(currencyInfo.decimals, 8);
+        const balance = balances[value.currency].value / (10 ** currencyInfo.decimals);
+        max = Math.round(balance * 10**roundedDecimalDigits) / 10**roundedDecimalDigits;
     } catch (e) {
         max = parseFloat((balances[value.currency] && balances[value.currency].valueReadable) || 0)
     }


### PR DESCRIPTION
**[Fix decimal rounding for BridgeInputBox "Max" balance button](https://github.com/ZigZagExchange/frontend/commit/ba7f8c86d025145b4134182e15722c820973b97b)**

> These changes fix-up a few issues with the "Max" button on the Bridge
panel.
>
> The token's decimals was calculated from the readable value rather than
relying on the decimals value declared in the token's contract. This was
causing rounding errors when the decimal was lead or trailed with zeros.
>
> The balance was always rounded to 8 decimals; however, some tokens have
a smaller number of decimals. This would cause an error to be thrown.
The balance is now rounded to eight or less decimals.

**[Validate Bridge input using actual wallet balance value](https://github.com/ZigZagExchange/frontend/commit/711d5b8dd52777e308ab4de0f3768452d7245e83)**

> These changes fix an error in the Bridge panel's input validation.
Previously an error of "insufficient funds" was displayed when the
user's entered value has more decimal accuracy than the rounded
"readable value".

**[Calculate maximum value on Bridge panel with fees subtracted](https://github.com/ZigZagExchange/frontend/pull/231/commits/c1beccf848a6190c9eb47cdcb9df574bd4c16cf2)** 

> These changes improve the behavior of the "Max" balance button by
subtracting the gas fees and transfer fees. This removes the need
for users to manually subtract fees from their desired transfer amount.

**Demo of issues fixed:**
_actual balance of 0.021895171680590212 Ether_

![demo-of-issues-fixed](https://user-images.githubusercontent.com/6083067/160530553-ca0aa267-9ee3-4ecf-bf39-65cb1f4c0b1d.png)

