### PR TITLE
Fix coin estimation for tokens which only have a UST pair

### DIFF
--- a/src/components/hooks/useCoinEstimator.js
+++ b/src/components/hooks/useCoinEstimator.js
@@ -1,8 +1,7 @@
 import { useMemo } from "react";
 import { useSelector } from "react-redux";
 import { lastPricesSelector } from "lib/store/features/api/apiSlice";
-
-const USD_REGEX = /^([A-Z]?USD[A-Z]|FRAX)?$/i;
+import { stables } from "lib/helpers/categories";
 
 export function useCoinEstimator() {
   const pairPrices = useSelector(lastPricesSelector);
@@ -11,10 +10,10 @@ export function useCoinEstimator() {
   return useMemo(() => {
     Object.keys(pairPrices).forEach((pair) => {
       const [a, b] = pair.split("-").map((s) => s.toUpperCase());
-      if (USD_REGEX.test(a)) {
+      if (stables.includes(a)) {
         prices[b] = pairPrices[pair].price;
       }
-      if (USD_REGEX.test(b)) {
+      if (stables.includes(b)) {
         prices[a] = pairPrices[pair].price;
       }
     });

--- a/src/components/organisms/TradeDashboard/TradeSidebar/TradePriceBtcTable/TradePriceBtcTable.jsx
+++ b/src/components/organisms/TradeDashboard/TradeSidebar/TradePriceBtcTable/TradePriceBtcTable.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import "./TradePriceBtcTable.css";
 import CategorizeBox from "../CategorizeBox/CategorizeBox";
 import SearchBox from "../SearchBox/SearchBox";
-import { getStables } from "../../../../../lib/helpers/categories/index.js";
+import { getStables } from "../../../../../lib/helpers/categories";
 import {
   addFavourite,
   removeFavourite,

--- a/src/lib/helpers/categories/index.js
+++ b/src/lib/helpers/categories/index.js
@@ -1,4 +1,4 @@
-const stables = ["USDC", "USDT", "DAI", "FRAX", "UST"];
+export const stables = ["USDC", "USDT", "DAI", "FRAX", "UST"];
 
 export function getStables(rows) {
   var found_stables = [];


### PR DESCRIPTION
The regex used by `useCoinEstimation` did not match the UST stablecoin.

This meant that the balance would always be zero if a token only had a
stablecoin pair using UST.

These changes leverage the existing category list to explicitly define
stablecoins.

![ust-coin-estimatator-out](https://user-images.githubusercontent.com/6083067/162560491-c692057d-85dc-455f-ab26-f86f6ecf8b34.png)


Comparing the return value of `useCoinEstimator` before and after shows that the following tokens will now have a price estimate: `TOKE, KEEP, DYDX, UNI, AAVE, YFI, LOOKS, GTC, CRV, METIS, LUNA, APE`

Here's how I got that:
```javascript
let pairPrices = {...}; // <-- pause debugger in useCoinEstimator to get this in-scope
let USD_REGEX = /^([A-Z]?USD[A-Z]|FRAX)?$/i;
let stablePairsBefore = {};
Object.keys(pairPrices).forEach((pair) => {
 const [a, b] = pair.split("-").map((s) => s.toUpperCase());
 if (USD_REGEX.test(a)) {
     if (stablePairsBefore[b] === undefined) stablePairsBefore[b] = [];
     stablePairsBefore[b].push(a)
 }
 if (USD_REGEX.test(b)) {
   if (stablePairsBefore[a] === undefined) stablePairsBefore[a] = [];
   stablePairsBefore[a].push(b)
 }
});
console.log('Tokens paired with loosely-defined stablecoin set: ', stablePairsBefore);

let stables = ["USDC", "USDT", "DAI", "FRAX", "UST"];
let stablePairsAfter = {};
Object.keys(pairPrices).forEach((pair) => {
 const [a, b] = pair.split("-").map((s) => s.toUpperCase());
 if (stables.includes(a)) {
     if (stablePairsAfter[b] === undefined) stablePairsAfter[b] = [];
     stablePairsAfter[b].push(a)
 }
 if (stables.includes(b)) {
   if (stablePairsAfter[a] === undefined) stablePairsAfter[a] = [];
   stablePairsAfter[a].push(b)
 }
});
console.log('Tokens paired with explicitly-defined stablecoin set: ', stablePairsAfter);

const fixedTokens = Object.keys(stablePairsAfter).filter(token => {
    return !Object.keys(stablePairsBefore).includes(token)
});
console.log('These changes fix USD price estimates for the following tokens: ', fixedTokens);
```