### PR TITLE
Fix/re send login after re connect

### DIFF
--- a/src/lib/api/API.js
+++ b/src/lib/api/API.js
@@ -221,6 +221,15 @@ export default class API extends Emitter {
         this.ws.addEventListener('message', this._socketMsg)
         this.ws.addEventListener('error', this._socketError)
         this.emit('start')
+
+        // login after reconnect
+        const accountState = this.getAccountState();
+        if (accountState && accountState.id) {
+          this.send("login", [
+            this.apiProvider.network,
+            accountState.id && accountState.id.toString(),
+          ]);
+        }
     }
 
     stop = () => {


### PR DESCRIPTION
This fixes this issues:
![grafik](https://user-images.githubusercontent.com/95502080/166516353-86f14d29-576b-48e5-8db4-709013a47510.png)

`It occurs when i leave for a moment. but when i come back to cancel the order ,it happended.`
> Most likly his ws restarted and without the login op, the backend does not know what ws is trying to send the cancel op