### PR TITLE
fix more then infinity issue

### DIFF
--- a/src/components/pages/BridgePage/Bridge/Bridge.jsx
+++ b/src/components/pages/BridgePage/Bridge/Bridge.jsx
@@ -213,7 +213,11 @@ const Bridge = (props) => {
     ) {
       const usdFee = await api.apiProvider.changePubKeyFee();
       setUsdFee(usdFee);
-      setActivationFee((usdFee / currencyValue).toFixed(5));
+      if (currencyValue) {
+        setActivationFee((usdFee / currencyValue).toFixed(5));
+      } else {
+        setActivationFee(0);
+      }
     }
   }, [swapDetails.currency, user.address]);
 


### PR DESCRIPTION
Sometimes user encounter a 'Must be more then Infinity' error while trying to bridge to L2. This is send here: https://github.com/ZigZagExchange/frontend/blob/875e5521422454021a16f9a246ca112e4b07f5e0/src/components/pages/BridgePage/Bridge/Bridge.jsx#L266-L267

The 'activationFee' can only be Infinity if no currencyValue is given (currencyValue == 0).