### PR TITLE
Disable Rinkeby

### DIFF
--- a/src/components/organisms/Header/Header.jsx
+++ b/src/components/organisms/Header/Header.jsx
@@ -50,13 +50,13 @@ const networkLists = [
     selectedIcon: <CheckIcon />,
     image: zksyncLogo,
   },
-  {
-    text: "zkSync - Rinkeby",
-    value: 1000,
-    url: "#",
-    selectedIcon: <CheckIcon />,
-    image: zksyncLogo,
-  },
+  //{
+  //  text: "zkSync - Rinkeby",
+  //  value: 1000,
+  //  url: "#",
+  //  selectedIcon: <CheckIcon />,
+  //  image: zksyncLogo,
+  //},
   {
     text: "Arbitrum (alpha)",
     value: 42161,


### PR DESCRIPTION
zksync has deprecated Rinkeby, so we're removing it from the network dropdown