### PR TITLE
fix: webview render too late, resulting innerHeight of 0

### DIFF
--- a/src/components/organisms/TradeDashboard/ReactGridLayout/layoutSettings.js
+++ b/src/components/organisms/TradeDashboard/ReactGridLayout/layoutSettings.js
@@ -1,4 +1,4 @@
-import { rowHeight } from "./utils";
+import { rowHeight, innerHeight } from './utils';
 
 function max(a, b) {
   return  a>b?a:b;
@@ -7,10 +7,10 @@ function max(a, b) {
 export const initialLayouts = () => {
   let unitHeight = rowHeight;
   let upperHeight;
-  if(window.innerWidth < 992 || window.innerHeight < 875) {
-    upperHeight= Math.ceil(470 / unitHeight);
+  if (window.innerWidth < 992 || innerHeight < 875) {
+    upperHeight = Math.ceil(470 / unitHeight);
   } else {
-    upperHeight= Math.ceil(570 / unitHeight);
+    upperHeight = Math.ceil(570 / unitHeight);
   }
 
   return {

--- a/src/components/organisms/TradeDashboard/ReactGridLayout/utils.js
+++ b/src/components/organisms/TradeDashboard/ReactGridLayout/utils.js
@@ -1,7 +1,7 @@
 // Some App webviews are rendered too late and will have an innerHeight of 0
 // The situation needs to be addressed with a compatible solution
 
-const innerHeight =
+export const innerHeight =
   window.innerHeight > 0 ? window.innerHeight : window.screen.height;
 
 export const rowHeight = (innerHeight - 112) / 30;

--- a/src/components/organisms/TradeDashboard/ReactGridLayout/utils.js
+++ b/src/components/organisms/TradeDashboard/ReactGridLayout/utils.js
@@ -1,1 +1,7 @@
-export const rowHeight = (window.innerHeight - 112) / 30;
+// Some App webviews are rendered too late and will have an innerHeight of 0
+// The situation needs to be addressed with a compatible solution
+
+const innerHeight =
+  window.innerHeight > 0 ? window.innerHeight : window.screen.height;
+
+export const rowHeight = (innerHeight - 112) / 30;


### PR DESCRIPTION
Fixing the wrong layout： [issues/1086](https://github.com/ZigZagExchange/frontend/issues/1086)

Some applications render webviews too late and will have an innerHeight of 0, 
when the rendering of the page has not yet started,
 and if this is encountered, then the `initialLayouts` [settings.layouts](https://github.com/ZigZagExchange/frontend/blob/master/src/components/organisms/TradeDashboard/ReactGridLayout/layoutSettings.js#L7) calculated afterward will be misaligned.

The situation needs to be addressed with a compatible solution

