### PR TITLE
fix reloading page

### DIFF
--- a/src/components/organisms/TradeDashboard/TradeDashboard.js
+++ b/src/components/organisms/TradeDashboard/TradeDashboard.js
@@ -162,7 +162,7 @@ export function TradeDashboard() {
         api.off("open", sub);
       }
     };
-  }, [network, currentMarket, settings.showNightPriceChange]);
+  }, [network, currentMarket, api.ws, settings.showNightPriceChange]);
 
   const changeSide = (side) => {
     setSide(side);

--- a/src/components/organisms/TradeDashboard/TradeDashboard.js
+++ b/src/components/organisms/TradeDashboard/TradeDashboard.js
@@ -140,9 +140,13 @@ export function TradeDashboard() {
   }, []);
 
   useEffect(async () => {
-    const sub = () => {
+    const sub = async () => {
       dispatch(resetData());
-      api.subscribeToMarket(currentMarket, settings.showNightPriceChange);
+      let subscribed = false;
+      while (!subscribed) {
+        subscribed = api.subscribeToMarket(currentMarket, settings.showNightPriceChange);
+        await new Promise(resolve => setTimeout(resolve, 200));
+      }
     };
 
     if (api.ws && api.ws.readyState === 0) {
@@ -158,7 +162,7 @@ export function TradeDashboard() {
         api.off("open", sub);
       }
     };
-  }, [network, currentMarket, api.ws, settings.showNightPriceChange]);
+  }, [network, currentMarket, settings.showNightPriceChange]);
 
   const changeSide = (side) => {
     setSide(side);

--- a/src/lib/api/API.js
+++ b/src/lib/api/API.js
@@ -590,13 +590,14 @@ class API extends Emitter {
       !allPairs.includes(market) &&
       market !== this.apiProvider.getDefaultMarket()
     )
-      return;
+      return false;
 
     this.send("subscribemarket", [
       this.apiProvider.network,
       market,
       showNightPriceChange,
     ]);
+    return true;
   };
 
   unsubscribeToMarket = (market) => {


### PR DESCRIPTION
- on page refresh that is not the default pair, the 'getPairs()' in L589 does not fetch any market cause the reqmarkets fetch is not yet successfully returned
- for that reason, the tradepage should retry until the request is successful